### PR TITLE
Add caveats to add_signal_handler()

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1046,6 +1046,14 @@ Unix signals
 
    Like :func:`signal.signal`, this function must be invoked in the main
    thread.
+   
+   While signal handlers registered using :func:`signal.signal` will
+   typically be called immediately, handlers registered using this
+   method are subject to potential delays while waiting for other 
+   work in the given event loop to be completed.
+   
+   Any event handler set for the same signal via :func:`signal.signal`
+   is implicitly removed by this method.
 
 .. method:: loop.remove_signal_handler(sig)
 


### PR DESCRIPTION
Add information about potential delays in callbacks registered by this function, and a note about the side effect that corresponding handlers registered directly by signal.signal() are implicitly removed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
